### PR TITLE
Give the right path of the standard library of the right cross-compiled OCaml compiler to Zarith

### DIFF
--- a/dune
+++ b/dune
@@ -25,11 +25,13 @@
  (target Makefile)
  (deps configure config.guess env)
  (action
-  (bash "env %{read:env} ./configure")))
+  (bash
+   "env %{read:env} ./configure --ocamllibdir %{ocaml-config:standard_library}")))
 
 (rule
  (target env)
- (action (copy gmp.%{lib-available:gmp} env)))
+ (action
+  (copy gmp.%{lib-available:gmp} env)))
 
 (rule
  (target gmp.true)
@@ -39,13 +41,18 @@
   %{lib:gmp:libgmp.so}
   %{lib:gmp:gmp.h})
  (action
-  (with-stdout-to %{target} (run %{exe} --cc "%{cc}" --with-gmp=%{lib:gmp:libgmp.a}))))
+  (with-stdout-to
+   %{target}
+   (run %{exe} --cc "%{cc}" --with-gmp=%{lib:gmp:libgmp.a}))))
 
 (rule
  (target gmp.false)
- (deps (:exe configure_env.exe))
+ (deps
+  (:exe configure_env.exe))
  (action
-  (with-stdout-to %{target} (run %{exe} --cc "%{cc}" --with-conf-gmp))))
+  (with-stdout-to
+   %{target}
+   (run %{exe} --cc "%{cc}" --with-conf-gmp))))
 
 (rule
  (target cflags.sexp)

--- a/zarith.opam
+++ b/zarith.opam
@@ -27,3 +27,4 @@ unboxed integers, for speed and space economy."""
 url {
  src: "git+https://github.com/mirage/Zarith.git#22adda581a979c020de856e85781814a0ad5769a"
 }
+tags: ["cross-compile"]


### PR DESCRIPTION
The `configure` in Zarith does not take the path of the cross-compiled OCaml compiler. That mostly means that if the OCaml cross-compiler tweaked a bit some `*.h`, Zarith, in the context of the cross-compilation, will not get right `*.h`. This patch gives to the `configure` the right path of the cross-compiled standard library when we compile with an other `dune`'s context.

/cc @TheLortex